### PR TITLE
Load libJetBrains.Profiler.CoreApi.so by its full path but not SONAME cos not supported on Linux musl

### DIFF
--- a/JetBrains.Profiler.Api/Impl/Linux/LibCSo6.cs
+++ b/JetBrains.Profiler.Api/Impl/Linux/LibCSo6.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
+
+namespace JetBrains.Profiler.Api.Impl.Linux
+{
+  internal static class LibCSo6
+  {
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int dl_iterate_phdr_callback_delegate(ref dl_phdr_info info, ulong size, IntPtr data);
+
+    private const string LibraryName = "libc.so.6"; // Note: Don't use libc.so because no such library in clean system!
+
+    [DllImport(LibraryName, ExactSpelling = true)]
+    public static extern int dl_iterate_phdr(dl_iterate_phdr_callback_delegate callback, IntPtr data);
+
+    [StructLayout(LayoutKind.Explicit, Size = 64)]
+    public struct dl_phdr_info
+    {
+      [FieldOffset(8)] public IntPtr dlpi_name;
+    }
+
+    public static class Helper
+    {
+      public static string DlIteratePhdrFindLibraryPath(string libraryName)
+      {
+        string found = null;
+        dl_iterate_phdr((ref dl_phdr_info info, ulong size, IntPtr data) =>
+        {
+          var path = Marshal.PtrToStringAnsi(info.dlpi_name);
+          if (path?.EndsWith($"/{libraryName}") ?? false)
+          {
+            found = path;
+            return 1;
+          }
+
+          return 0;
+        }, IntPtr.Zero);
+
+        return found;
+      }
+    }
+  }
+}

--- a/JetBrains.Profiler.Api/Impl/Linux/LibCSo6.cs
+++ b/JetBrains.Profiler.Api/Impl/Linux/LibCSo6.cs
@@ -8,38 +8,21 @@ namespace JetBrains.Profiler.Api.Impl.Linux
 {
   internal static class LibCSo6
   {
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate int dl_iterate_phdr_callback_delegate(ref dl_phdr_info info, ulong size, IntPtr data);
-
     private const string LibraryName = "libc.so.6"; // Note: Don't use libc.so because no such library in clean system!
 
-    [DllImport(LibraryName, ExactSpelling = true)]
-    public static extern int dl_iterate_phdr(dl_iterate_phdr_callback_delegate callback, IntPtr data);
-
-    [StructLayout(LayoutKind.Explicit, Size = 64)]
-    public struct dl_phdr_info
+    public static class Bitness64
     {
-      [FieldOffset(8)] public IntPtr dlpi_name;
-    }
+      [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+      public delegate int dl_iterate_phdr_callback(ref dl_phdr_info info, ulong size, IntPtr data);
 
-    public static class Helper
-    {
-      public static string DlIteratePhdrFindLibraryPath(string libraryName)
+      [DllImport(LibraryName, ExactSpelling = true)]
+      public static extern int dl_iterate_phdr(dl_iterate_phdr_callback callback, IntPtr data);
+
+      [StructLayout(LayoutKind.Explicit, Size = 64)]
+      public struct dl_phdr_info
       {
-        string found = null;
-        dl_iterate_phdr((ref dl_phdr_info info, ulong size, IntPtr data) =>
-        {
-          var path = Marshal.PtrToStringAnsi(info.dlpi_name);
-          if (path?.EndsWith($"/{libraryName}") ?? false)
-          {
-            found = path;
-            return 1;
-          }
-
-          return 0;
-        }, IntPtr.Zero);
-
-        return found;
+        [FieldOffset(8)]
+        public IntPtr dlpi_name;
       }
     }
   }

--- a/JetBrains.Profiler.Api/Impl/Linux/LibCoreApiSo.cs
+++ b/JetBrains.Profiler.Api/Impl/Linux/LibCoreApiSo.cs
@@ -57,7 +57,7 @@ namespace JetBrains.Profiler.Api.Impl.Linux
 
     static LibCoreApiSo()
     {
-      string libraryPath = LibCSo6.Helper.DlIteratePhdrFindLibraryPath(LibraryName) ?? throw new DllNotFoundException($"Failed to find library {LibraryName}");
+      string libraryPath = LinuxHelper.DlIteratePhdrFindLibraryPath(LibraryName) ?? throw new DllNotFoundException($"Failed to find library {LibraryName}");
       ourLibraryHandle = new SafeDlHandle(LibDlSo2.dlopen(libraryPath, RTLD.RTLD_GLOBAL | RTLD.RTLD_LAZY));
       if (ourLibraryHandle.Handle == IntPtr.Zero)
         throw new DllNotFoundException($"Failed to load library {LibraryName}");

--- a/JetBrains.Profiler.Api/Impl/Linux/LibDlSo2.cs
+++ b/JetBrains.Profiler.Api/Impl/Linux/LibDlSo2.cs
@@ -14,6 +14,9 @@ namespace JetBrains.Profiler.Api.Impl.Linux
     public static extern IntPtr dlopen([MarshalAs(UnmanagedType.LPStr)] string filename, int flags);
 
     [DllImport(LibraryName, ExactSpelling = true)]
+    public static extern IntPtr dlsym(IntPtr handle, [MarshalAs(UnmanagedType.LPStr)] string symbol);
+
+    [DllImport(LibraryName, ExactSpelling = true)]
     public static extern int dlclose(IntPtr handle);
   }
 }

--- a/JetBrains.Profiler.Api/Impl/Linux/LinuxHelper.cs
+++ b/JetBrains.Profiler.Api/Impl/Linux/LinuxHelper.cs
@@ -1,16 +1,12 @@
-using System;
-
+﻿
 namespace JetBrains.Profiler.Api.Impl.Linux
 {
   internal static class LinuxHelper
   {
     public static bool IsCoreApiAlreadyLoaded()
     {
-      var handle = LibDlSo2.dlopen(LibCoreApiSo.LibraryName, RTLD.RTLD_GLOBAL | RTLD.RTLD_LAZY | RTLD.RTLD_NOLOAD);
-      if (handle == IntPtr.Zero)
-        return false;
-      LibDlSo2.dlclose(handle);
-      return true;
+      // Note(k15tfu): dlopen() in musl ignores SONAME, use dl_iterate_phdr().  See https://www.openwall.com/lists/musl/2022/01/11/4.
+      return LibCSo6.Helper.DlIteratePhdrFindLibraryPath(LibCoreApiSo.LibraryName) != null;
     }
   }
 }

--- a/JetBrains.Profiler.Api/Impl/Linux/LinuxHelper.cs
+++ b/JetBrains.Profiler.Api/Impl/Linux/LinuxHelper.cs
@@ -1,4 +1,6 @@
-﻿
+﻿using System;
+using System.Runtime.InteropServices;
+
 namespace JetBrains.Profiler.Api.Impl.Linux
 {
   internal static class LinuxHelper
@@ -6,7 +8,23 @@ namespace JetBrains.Profiler.Api.Impl.Linux
     public static bool IsCoreApiAlreadyLoaded()
     {
       // Note(k15tfu): dlopen() in musl ignores SONAME, use dl_iterate_phdr().  See https://www.openwall.com/lists/musl/2022/01/11/4.
-      return LibCSo6.Helper.DlIteratePhdrFindLibraryPath(LibCoreApiSo.LibraryName) != null;
+      return DlIteratePhdrFindLibraryPath(LibCoreApiSo.LibraryName) != null;
+    }
+
+    public static string DlIteratePhdrFindLibraryPath(string libraryName)
+    {
+      string found = null;
+      var tailLibraryName = '/' + libraryName;
+      if (IntPtr.Size == 8)
+        LibCSo6.Bitness64.dl_iterate_phdr((ref LibCSo6.Bitness64.dl_phdr_info info, ulong size, IntPtr data) =>
+          {
+            var path = Marshal.PtrToStringAnsi(info.dlpi_name);
+            if (path == null || !path.EndsWith(tailLibraryName))
+              return 0;
+            found = path;
+            return 1;
+          }, IntPtr.Zero);
+      return found;
     }
   }
 }

--- a/JetBrains.Profiler.Api/JetBrains.Profiler.Api.csproj
+++ b/JetBrains.Profiler.Api/JetBrains.Profiler.Api.csproj
@@ -12,14 +12,14 @@
     <Copyright>Copyright © 2019-$([System.DateTime]::Now.ToString('yyyy')) JetBrains s.r.o.</Copyright>
     <Authors>Mikhail Pilin</Authors>
     <Description>JetBrains Profiler API allows you to control profiling sessions right from the code of your application. Use this API in conjunction with JetBrains dotTrace, JetBrains dotMemory, or JetBrains dotCover. This API can also be used in conjunction with JetBrains Self-Profiling API.</Description>
-    <PackageReleaseNotes>• Supported OSs: Windows 7 x86/x64 and later, macOS 10.12 Sierra - 10.15 Catalina x64, macOS 11.0 Big Sur x64/arm64 and later, Linux x64/arm64 (most desktop distributions like CentOS, Debian, Fedora, Ubuntu and derivatives)
+    <PackageReleaseNotes>• Supported OSs: Windows 7 x86/x64 and later, macOS 10.12 Sierra - 10.15 Catalina x64, macOS 11.0 Big Sur x64/arm64 and later, Linux Glibc/Musl x64/arm64 (most desktop distributions like Alpine, CentOS, Debian, Fedora, Ubuntu and derivatives)
 • Supported frameworks: .NET Framework 2.0 and later, .NET Standard 1.1 and later, .NET Core 1.0 and later, .NET 5.0 and later, Mono 5.10 and later</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/JetBrains/profiler-api</RepositoryUrl>
     <PackageProjectUrl>https://github.com/JetBrains/profiler-api/blob/master/README.md</PackageProjectUrl>
     <PackageIconUrl>https://resources.jetbrains.com/storage/products/resharper/img/icons/ProfilerApi_128.png</PackageIconUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageTags>jetbrains profiler profiling performance memory coverage net dotnet netcore dotnetcore netstandard windows uwp macos mac linux x86 x64 arm64 x86-64 x86_64 aarch64</PackageTags>
-    <Version>1.1.8</Version>
+    <Version>1.2.0-preview1</Version>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">


### PR DESCRIPTION
Load libJetBrains.Profiler.CoreApi.so by its full path but not SONAME cos not supported on Linux musl

https://www.openwall.com/lists/musl/2022/01/11/4